### PR TITLE
Updates to make it mongoid v6 compatible.

### DIFF
--- a/lib/mongoid/core_ext/relations/options.rb
+++ b/lib/mongoid/core_ext/relations/options.rb
@@ -1,7 +1,12 @@
 module Mongoid
   module Relations
     module Options
-      COMMON << :versioned
+      alias_method :validate_without_versioned!, :validate!
+
+      def validate!(options)
+        options_without_versioned = options.except(:versioned)
+        validate_without_versioned!(options_without_versioned)
+      end
     end
   end
 end

--- a/lib/mongoid/core_ext/versioning.rb
+++ b/lib/mongoid/core_ext/versioning.rb
@@ -139,10 +139,11 @@ module Mongoid
         mongo_session.options
 
       _loading_revision do
-        self.class.unscoped
-          .with(options)
-          .where(_id: id)
-          .any_of({ version: version }, version: nil).first
+        self.class.with(options) do |m|
+          m.unscoped
+           .where(_id: id)
+           .any_of({ version: version }, version: nil).first
+        end
       end
     end
 


### PR DESCRIPTION
- In Mongoid v6, the Mongoid::Relations::Options::COMMON const is now
  frozen. So we cannot include the :versioned option in it anymore. This commit hacks
  the :validate! method to remove the :versioned from the list of options being validated.

- It also updates the usage of Mongoid::Clients::Options#with method due to interface change.