### PR TITLE
Update Mongoid version to 7.4.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.0', '3.1']
-        mongoid: ['73']
+        mongoid: ['74']
         mongodb: ['4.4', '5.0']
 
     runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'mongoid', "~> 7.3.5"
+gem 'mongoid', "~> 7.4.3"

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ Mongoid supports simple versioning through inclusion of the `Mongoid::Versioning
 
 This fork has additional changes to support the following mongoid/ruby versions:
 
-|                 | branch                                                                            | mongoid-paranoid support | Tested ruby version(s) | Build |
-|-----------------|-----------------------------------------------------------------------------------|--------------------------|------------------------|-------|
-| mongoid <5      | [master](https://github.com/fullhealthmedical/mongoid-versioning/tree/master)     | Yes                      | 2.5, 2.6               | ![Build](https://github.com/fullhealthmedical/mongoid-versioning/actions/workflows/build.yml/badge.svg?branch=master) |
-| mongoid 6       | [mongoid6](https://github.com/fullhealthmedical/mongoid-versioning/tree/mongoid6) | No                       | 2.7                    | ![Build](https://github.com/fullhealthmedical/mongoid-versioning/actions/workflows/build.yml/badge.svg?branch=mongoid6) |
-| mongoid >= 7.0 < 7.3.5 | [mongoid7](https://github.com/fullhealthmedical/mongoid-versioning/tree/mongoid7) | No                       | 2.7                    | ![Build](https://github.com/fullhealthmedical/mongoid-versioning/actions/workflows/build.yml/badge.svg?branch=mongoid7) |
-| mongoid >= 7.0 < 7.3.5 | [mongoid7](https://github.com/fullhealthmedical/mongoid-versioning/tree/mongoid73) | No                       | 2.7                    | ![Build](https://github.com/fullhealthmedical/mongoid-versioning/actions/workflows/build.yml/badge.svg?branch=mongoid73) |
+|                          | branch                                                                             | mongoid-paranoid support | Tested ruby version(s) | Build |
+|--------------------------|------------------------------------------------------------------------------------|--------------------------|------------------------|-------|
+| mongoid <5               | [master](https://github.com/fullhealthmedical/mongoid-versioning/tree/master)      | Yes                      | 2.5, 2.6               | ![Build](https://github.com/fullhealthmedical/mongoid-versioning/actions/workflows/build.yml/badge.svg?branch=master) |
+| mongoid 6                | [mongoid6](https://github.com/fullhealthmedical/mongoid-versioning/tree/mongoid6)  | No                       | 2.7                    | ![Build](https://github.com/fullhealthmedical/mongoid-versioning/actions/workflows/build.yml/badge.svg?branch=mongoid6) |
+| mongoid >= 7.0 < 7.3.5   | [mongoid7](https://github.com/fullhealthmedical/mongoid-versioning/tree/mongoid7)  | No                       | 2.7                    | ![Build](https://github.com/fullhealthmedical/mongoid-versioning/actions/workflows/build.yml/badge.svg?branch=mongoid7) |
+| mongoid >= 7.0 < 7.3.5   | [mongoid7](https://github.com/fullhealthmedical/mongoid-versioning/tree/mongoid73) | No                       | 2.7                    | ![Build](https://github.com/fullhealthmedical/mongoid-versioning/actions/workflows/build.yml/badge.svg?branch=mongoid73) |
+| mongoid >= 7.3.5 < 7.4.3 | [mongoid7](https://github.com/fullhealthmedical/mongoid-versioning/tree/mongoid74) | No                       | 3.0, 3.1               | ![Build](https://github.com/fullhealthmedical/mongoid-versioning/actions/workflows/build.yml/badge.svg?branch=mongoid73) |
 
 In your Gemfile:
 

--- a/gemfiles/Mongoid_74.gemfile
+++ b/gemfiles/Mongoid_74.gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gemspec path: '../'
 
-gem 'mongoid', '~> 7.3.5'
+gem 'mongoid', '~> 7.4.3'

--- a/lib/mongoid/versioning/version.rb
+++ b/lib/mongoid/versioning/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module Versioning
-    VERSION = '3.0.0'.freeze
+    VERSION = '4.0.0'.freeze
   end
 end

--- a/mongoid-versioning.gemspec
+++ b/mongoid-versioning.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_path  = 'lib'
 
   gem.add_dependency 'activesupport', '>= 4.0'
-  gem.add_dependency 'mongoid', '~> 7.3.5'
+  gem.add_dependency 'mongoid', '~> 7.4.3'
   gem.add_development_dependency 'rake', '~> 10.0'
   gem.add_development_dependency 'rspec', '~> 3'
 end


### PR DESCRIPTION
This increases the Mongoid version dependency to 7.4.3 in README.md, Gemfile, and Mongoid_74.gemfile, ensuring compatibility with this Mongoid version. The change in README.md also accurately reflects the updated version support.